### PR TITLE
Add multi-stage Dockerfile and .dockerignore for backend API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Node modules and Vite cache
+FrontEnd/node_modules/
+FrontEnd/.vite/
+
+# Vite build output folders
+FrontEnd/dist/
+FrontEnd/build/
+
+# Backend build artifacts
+BackEnd/FinSight.api/bin/
+BackEnd/FinSight.api/obj/
+
+# IDE and editor files
+.vscode/
+*.user
+*.suo
+
+# Git files
+.git/
+.gitignore
+
+# Docs
+*.md
+
+# Dockerfiles to avoid recursion
+**/Dockerfile

--- a/BackEnd/FinSight.api/.dockerignore
+++ b/BackEnd/FinSight.api/.dockerignore
@@ -1,0 +1,20 @@
+# Build folders
+bin/
+obj/
+
+# Visual Studio / IDE files
+.vscode/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# Git files 
+.git/
+.gitignore
+
+# Docker files (to avoid recursion)
+Dockerfile
+
+# Documentation and misc
+*.md

--- a/BackEnd/FinSight.api/Dockerfile
+++ b/BackEnd/FinSight.api/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["BackEnd/FinSight.api/FinSight.api.csproj", "BackEnd/FinSight.api/"]
+RUN dotnet restore "BackEnd/FinSight.api/FinSight.api.csproj"
+COPY ["BackEnd/FinSight.api/", "BackEnd/FinSight.api/"]
+WORKDIR "/src/BackEnd/FinSight.api"
+RUN dotnet build "FinSight.api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "FinSight.api.csproj" -c $BUILD_CONFIGURATION -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "FinSight.api.dll", "--urls", "http://+:8080"]


### PR DESCRIPTION
1. Added a multi-stage Dockerfile for the backend .NET 8 Web API to optimize build and image size.
2. Dockerfile uses 4 stages: base, build, publish, and final for efficient layering.
3. Configured the app to listen on HTTP port 8080 inside the container (HTTPS disabled to avoid cert issues).
4. Included a .dockerignore file in the backend folder to exclude unnecessary files and speed up Docker builds.
5. Added a root .dockerignore to prevent including unnecessary files from the project root.
6. Verified the backend API runs successfully inside a Docker container with port mapping.